### PR TITLE
Ensure that index returned in Bar.getNearestTickIndex is valid.

### DIFF
--- a/rangebar/src/com/edmodo/rangebar/Bar.java
+++ b/rangebar/src/com/edmodo/rangebar/Bar.java
@@ -127,6 +127,10 @@ class Bar {
 
         final int nearestTickIndex = (int) ((thumb.getX() - mLeftX + mTickDistance / 2f) / mTickDistance);
 
+        if (nearestTickIndex < 0) return 0;
+
+        if (nearestTickIndex > mNumSegments) return mNumSegments;
+
         return nearestTickIndex;
     }
 


### PR DESCRIPTION
Change-Id: Iacc3759285d967b9f23b40cd9cf3f8d8dfa22248
